### PR TITLE
refactor: 로그인, 회원가입 엔드포인트 분리

### DIFF
--- a/my-app/src/app/signup/layout.js
+++ b/my-app/src/app/signup/layout.js
@@ -1,0 +1,29 @@
+'use client'
+
+import { Heart, Sparkles } from "lucide-react"
+
+export default function LoginLayout({ children }) {
+  return (
+    <div className="min-h-screen w-full bg-gradient-to-br from-gray-900 via-black to-gray-800 flex items-center justify-center p-4 relative overflow-hidden">
+      
+      {/* 배경 애니메이션 아이콘 */}
+      <div className="absolute top-20 left-20 text-[#00aec6]/30 animate-bounce">
+        <Heart className="w-6 h-6" fill="currentColor" />
+      </div>
+      <div className="absolute top-32 right-32 text-[#0067ac]/30 animate-pulse">
+        <Sparkles className="w-5 h-5" />
+      </div>
+      <div className="absolute bottom-40 left-40 text-[#00aec6]/30 animate-bounce delay-1000">
+        <Heart className="w-4 h-4" fill="currentColor" />
+      </div>
+      <div className="absolute bottom-20 right-20 text-[#00aec6]/30 animate-pulse delay-500">
+        <Sparkles className="w-6 h-6" />
+      </div>
+
+      {/* 가운데 카드 콘텐츠 */}
+      <div className="w-full max-w-md relative z-10">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/my-app/src/app/signup/page.tsx
+++ b/my-app/src/app/signup/page.tsx
@@ -2,5 +2,5 @@
 import AuthCard from "../ui/login/AuthCard";
 
 export default function Page() {
-  return <AuthCard mode="login" />;
+  return <AuthCard mode="signup" />;
 }

--- a/my-app/src/app/ui/MainPage/CTAButtons.tsx
+++ b/my-app/src/app/ui/MainPage/CTAButtons.tsx
@@ -19,7 +19,7 @@ export default function CTAButtons() {
           className="flex-1 py-3 text-base font-semibold text-blue-950 border-white/30 rounded-full hover:border-[#00AEC6]"
         >
           {/* TODO: signup 페이지 분리*/}
-          <Link href="/login">회원가입하기</Link>
+          <Link href="/signup">회원가입하기</Link>
         </Button>
       </div>
     </div>

--- a/my-app/src/app/ui/login/AuthCard.tsx
+++ b/my-app/src/app/ui/login/AuthCard.tsx
@@ -1,67 +1,92 @@
-'use client'
+"use client";
 
-import { useState } from 'react'
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Heart, Sparkles, User } from 'lucide-react'
-import LoginForm from './LoginForm'
-import SignupForm from './SignupForm'
-import { useRouter } from "next/navigation"
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Heart, Sparkles, User } from "lucide-react";
+import LoginForm from "./LoginForm";
+import SignupForm from "./SignupForm";
+import { useRouter } from "next/navigation";
 
-export default function AuthCard() {
-  const router = useRouter()
+interface AuthCardProps {
+  mode: "login" | "signup";
+}
 
-  const [isLogin, setIsLogin] = useState(true)
-  const [isLoggedIn, setIsLoggedIn] = useState(false)
-  const [showPassword, setShowPassword] = useState(false)
-  const [userData, setUserData] = useState({ name: '', userId: '' })
+export default function AuthCard({ mode }: AuthCardProps) {
+  const router = useRouter();
+
+  const [isLogin, setIsLogin] = useState(mode === "login");
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [userData, setUserData] = useState({ name: "", userId: "" });
 
   const handleLogin = (e: React.FormEvent) => {
-    e.preventDefault()
-    const formData = new FormData(e.target as HTMLFormElement)
-    const userId = formData.get('userId') as string
+    e.preventDefault();
+    const formData = new FormData(e.target as HTMLFormElement);
+    const userId = formData.get("userId") as string;
 
-    setIsLoggedIn(true)
-    setUserData({ name: '사용자', userId })
-  }
+    setIsLoggedIn(true);
+    setUserData({ name: "사용자", userId });
+  };
 
   const handleSignup = (e: React.FormEvent) => {
-    e.preventDefault()
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = formData.get('name') as string
-    const userId = formData.get('userId') as string
+    e.preventDefault();
+    const formData = new FormData(e.target as HTMLFormElement);
+    const name = formData.get("name") as string;
+    const userId = formData.get("userId") as string;
 
-    setIsLoggedIn(true)
-    setUserData({ name, userId })
-  }
+    setIsLoggedIn(true);
+    setUserData({ name, userId });
+  };
 
   const handleLogout = () => {
-    setIsLoggedIn(false)
-    setUserData({ name: '', userId: '' })
-  }
+    setIsLoggedIn(false);
+    setUserData({ name: "", userId: "" });
+  };
 
   const togglePasswordVisibility = () => {
-    setShowPassword(!showPassword)
-  }
+    setShowPassword(!showPassword);
+  };
 
   const switchAuthMode = () => {
-    setIsLogin(!isLogin)
-  }
+    setIsLogin(!isLogin);
+  };
 
   return (
     <Card className="w-full max-w-md bg-gray-900/80 backdrop-blur-xl border border-gray-700/50 shadow-2xl rounded-3xl overflow-hidden relative z-10">
-      <div className="absolute inset-0" style={{ background: 'linear-gradient(135deg, rgba(0, 103, 172, 0.05) 0%, rgba(0, 174, 198, 0.05) 100%)' }}></div>
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            "linear-gradient(135deg, rgba(0, 103, 172, 0.05) 0%, rgba(0, 174, 198, 0.05) 100%)",
+        }}
+      ></div>
 
       <CardHeader className="text-center space-y-6 relative z-10 pt-8">
-        <div className="mx-auto w-20 h-20 rounded-full flex items-center justify-center shadow-lg animate-pulse" style={{ background: 'linear-gradient(135deg, #0067ac 0%, #00aec6 100%)' }}>
-          {isLogin ? <User className="w-10 h-10 text-white" /> : <Heart className="w-10 h-10 text-white" fill="currentColor" />}
+        <div
+          className="mx-auto w-20 h-20 rounded-full flex items-center justify-center shadow-lg animate-pulse"
+          style={{
+            background: "linear-gradient(135deg, #0067ac 0%, #00aec6 100%)",
+          }}
+        >
+          {isLogin ? (
+            <User className="w-10 h-10 text-white" />
+          ) : (
+            <Heart className="w-10 h-10 text-white" fill="currentColor" />
+          )}
         </div>
         <div>
           <CardTitle className="text-3xl font-light text-white mb-2">
-            {isLogin ? '로그인 🌙' : '회원가입 ✨'}
+            {isLogin ? "로그인 🌙" : "회원가입 ✨"}
           </CardTitle>
           <CardDescription className="text-gray-300 text-base">
-            {isLogin ? 'Kiri-Kiri ' : 'Kiri-Kiri 환영합니다'}
+            {isLogin ? "Kiri-Kiri " : "Kiri-Kiri 환영합니다"}
           </CardDescription>
         </div>
       </CardHeader>
@@ -85,10 +110,10 @@ export default function AuthCard() {
             onClick={switchAuthMode}
             className="text-gray-400 hover:text-white text-sm font-medium hover:bg-gray-800/50 rounded-xl px-6 py-3 transition-all duration-300"
           >
-            {isLogin ? '회원가입하기' : '로그인하기'}
+            {isLogin ? "회원가입하기" : "로그인하기"}
           </Button>
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }


### PR DESCRIPTION
### ✅ 작업 내용
- 회원 가입과 로그인 엔드포인트 분리 (/signup, /login)

### 🔍 주요 변경 사항
- `src/app/signup` 추가
- `/login`과 `/signup` 각각의 page.tsx에서 AuthCard에 모드 props 전달하도록 분리
- AuthCard가 mode에 따라 로그인/회원가입 UI 렌더링

### ⚠️ 참고 사항


### 🖼️ 이미지
- 회원가입 창 이동
![redirect_signup_page](https://github.com/user-attachments/assets/17a3ccf1-38d8-4d2a-b688-3bb94276ae4b)
