### PR TITLE
refactor: app/profile/page.tsx를 서버 컴포넌트로 전환

### DIFF
--- a/my-app/src/app/profile/page.tsx
+++ b/my-app/src/app/profile/page.tsx
@@ -1,6 +1,5 @@
-"use client";
+// 서버 컴포넌트로 전환
 
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Settings, MoreHorizontal, Grid3X3 } from "lucide-react";
@@ -8,17 +7,14 @@ import ProfileHeader from "../ui/Profile/ProfileHeader";
 import PostsGrid from "../ui/Profile/PostsGrid";
 
 export default function SNSProfile() {
-  const [isFollowing, setIsFollowing] = useState(false);
-  const [followerCount, setFollowerCount] = useState(1234);
-
-  const handleFollowToggle = () => {
-    setIsFollowing(!isFollowing);
-    setFollowerCount((prev) => (isFollowing ? prev - 1 : prev + 1));
-  };
+  // 임시 placeholder
+  const isFollowing = false;
+  const followerCount = 123;
+  const name= '김우리';
+  const bio = '안녕하세요. 여행과 사진을 좋아하는 개발자입니다✨';
 
   return (
     <div className="space-y-8 bg-gray-50">
-      {/* Top Header */}
       <div className="sticky top-0 z-10 bg-white">
         <div className="border-b border-gray-200 px-6 py-4 flex items-center justify-between">
           <h1 className="text-xl font-semibold text-[#123F6D]">프로필</h1>
@@ -39,7 +35,8 @@ export default function SNSProfile() {
             <ProfileHeader
               isFollowing={isFollowing}
               followerCount={followerCount}
-              onToggleFollow={handleFollowToggle}
+              name={name}
+              bio={bio}
             />
           </CardContent>
         </Card>

--- a/my-app/src/app/ui/Profile/ProfileHeader.tsx
+++ b/my-app/src/app/ui/Profile/ProfileHeader.tsx
@@ -4,21 +4,24 @@ import ProfileInfo from "./ProfileInfo";
 interface Props {
   isFollowing: boolean;
   followerCount: number;
-  onToggleFollow: () => void;
+  name: string;
+  bio: string;
 }
 
 export default function ProfileHeader({
   isFollowing,
   followerCount,
-  onToggleFollow,
+  name,
+  bio,
 }: Props) {
   return (
     <div className="flex items-start gap-8">
-      <ProfileImage />
+      <ProfileImage name={name}/>
       <ProfileInfo
         isFollowing={isFollowing}
         followerCount={followerCount}
-        onToggleFollow={onToggleFollow}
+        name={name}
+        bio={bio}
       />
     </div>
   );

--- a/my-app/src/app/ui/Profile/ProfileImage.tsx
+++ b/my-app/src/app/ui/Profile/ProfileImage.tsx
@@ -1,14 +1,14 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Camera } from "lucide-react";
 
-export default function ProfileImage() {
+export default function ProfileImage({ name }:{ name: string }) {
   return (
     <div className="relative group">
       <div className="w-32 h-32 rounded-full bg-gradient-to-br from-[#00AEC6] via-[#0067AC] to-[#123F6D] p-1 shadow-lg">
         <Avatar className="w-full h-full border-4 border-white">
           <AvatarImage src="/placeholder.svg?height=128&width=128&text=Profile" />
           <AvatarFallback className="bg-gradient-to-br from-[#00AEC6] to-[#0067AC] text-white text-lg font-medium">
-            김철수
+            {name}
           </AvatarFallback>
         </Avatar>
       </div>

--- a/my-app/src/app/ui/Profile/ProfileInfo.tsx
+++ b/my-app/src/app/ui/Profile/ProfileInfo.tsx
@@ -4,18 +4,22 @@ import { UserPlus, UserMinus } from "lucide-react";
 interface Props {
   isFollowing: boolean;
   followerCount: number;
-  onToggleFollow: () => void;
+  name: string;
+  bio: string;
+  onToggleFollow?: () => void;
 }
 
 export default function ProfileInfo({
   isFollowing,
   followerCount,
+  name,
+  bio,
   onToggleFollow,
 }: Props) {
   return (
     <div className="flex-1">
       <div className="flex items-center gap-4 mb-4">
-        <h2 className="text-2xl font-bold text-[#123F6D]">김철수</h2>
+        <h2 className="text-2xl font-bold text-[#123F6D]">{name}</h2>
         <Button
           onClick={onToggleFollow}
           className={`px-8 py-2.5 rounded-full font-medium transition-all ${
@@ -39,9 +43,7 @@ export default function ProfileInfo({
       </div>
 
       <p className="text-[#123F6D]/80 text-lg mb-6 leading-relaxed">
-        안녕하세요! 여행과 사진을 좋아하는 개발자입니다.
-        <br />
-        새로운 경험과 사람들과의 만남을 소중히 여깁니다 ✨
+        {bio}
       </p>
 
       <div className="flex items-center gap-8 mb-6">
@@ -51,6 +53,7 @@ export default function ProfileInfo({
           </div>
           <div className="text-sm text-[#123F6D]/60">팔로워</div>
         </div>
+        {/* 팔로잉, 게시물은 하드코딩된 상태 */}
         <div className="text-center">
           <div className="text-2xl font-bold text-[#123F6D]">892</div>
           <div className="text-sm text-[#123F6D]/60">팔로잉</div>


### PR DESCRIPTION
### ✅ 주요 변경 사항

* `app/profile/page.tsx`를 **서버 컴포넌트**로 전환
  → 기존 `useState` 기반 클라이언트 컴포넌트 제거
* `isFollowing`, `followerCount`, `name`, `bio`를 **placeholder 값으로 props 전달**
* `ProfileHeader`, `ProfileInfo`, `ProfileImage` 컴포넌트에 **필요한 props 구조화**

  * `name`, `bio` 값 상위에서 받아 렌더링
  * `AvatarFallback`, 사용자 이름 출력 등에 적용

---

### 🧱 변경된 구조 흐름

```
page.tsx (서버)
  └── ProfileHeader(props)
        ├── ProfileImage(name)
        └── ProfileInfo(name, bio, isFollowing, followerCount)
```

---

### 📁 변경된 파일

* `app/profile/page.tsx`
* `ui/profile/ProfileHeader.tsx`
* `ui/profile/ProfileInfo.tsx`
* `ui/profile/ProfileImage.tsx`

---

### 🖼️ 참고 이미지
<img width="1912" height="904" alt="프로필 화면" src="https://github.com/user-attachments/assets/19c74ce1-9baa-419c-a507-1d7e485b4559" />
