### PR TITLE
feat: getUserProfile()함수 통해 DB에서 유저 프로필 조회 구현

### DIFF
--- a/my-app/package.json
+++ b/my-app/package.json
@@ -4,10 +4,20 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "postinstall": "prisma generate",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "seed": "ts-node prisma/seed.ts"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/client",
+      "@prisma/engines",
+      "@tailwindcss/oxide",
+      "prisma",
+      "sharp"
+    ]
   },
   "dependencies": {
     "@prisma/client": "^6.12.0",

--- a/my-app/pnpm-lock.yaml
+++ b/my-app/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 10.9.2(@types/node@20.19.9)(typescript@5.8.3)
       tw-animate-css:
         specifier: ^1.3.5
-        version: 1.3.5
+        version: 1.3.6
       typescript:
         specifier: ^5
         version: 5.8.3
@@ -651,8 +651,8 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
-  jiti@2.5.0:
-    resolution: {integrity: sha512-NWDAhdnATItTnRhip9VTd8oXDjVcbhetRN6YzckApnXGxpGUooKMAaf0KVvlZG0+KlJMGkeLElVn4M1ReuxKUQ==}
+  jiti@2.5.1:
+    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
   lightningcss-darwin-arm64@1.30.1:
@@ -867,8 +867,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tw-animate-css@1.3.5:
-    resolution: {integrity: sha512-t3u+0YNoloIhj1mMXs779P6MO9q3p3mvGn4k1n3nJPqJw/glZcuijG2qTSN4z4mgNRfW5ZC3aXJFLwDtiipZXA==}
+  tw-animate-css@1.3.6:
+    resolution: {integrity: sha512-9dy0R9UsYEGmgf26L8UcHiLmSFTHa9+D7+dAt/G/sF5dCnPePZbfgDYinc7/UzAM7g/baVrmS6m9yEpU46d+LA==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -1200,7 +1200,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       enhanced-resolve: 5.18.2
-      jiti: 2.5.0
+      jiti: 2.5.1
       lightningcss: 1.30.1
       magic-string: 0.30.17
       source-map-js: 1.2.1
@@ -1348,7 +1348,7 @@ snapshots:
 
   jiti@2.4.2: {}
 
-  jiti@2.5.0: {}
+  jiti@2.5.1: {}
 
   lightningcss-darwin-arm64@1.30.1:
     optional: true
@@ -1550,7 +1550,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tw-animate-css@1.3.5: {}
+  tw-animate-css@1.3.6: {}
 
   typescript@5.8.3: {}
 

--- a/my-app/src/app/profile/page.tsx
+++ b/my-app/src/app/profile/page.tsx
@@ -5,13 +5,16 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Settings, MoreHorizontal, Grid3X3 } from "lucide-react";
 import ProfileHeader from "../ui/Profile/ProfileHeader";
 import PostsGrid from "../ui/Profile/PostsGrid";
+import { getUserProfile } from "@/lib/profile";
 
-export default function SNSProfile() {
-  // 임시 placeholder
-  const isFollowing = false;
-  const followerCount = 123;
-  const name= '김우리';
-  const bio = '안녕하세요. 여행과 사진을 좋아하는 개발자입니다✨';
+export default async function SNSProfile() {
+  // 비동기 함수이므로, DB 요청이 끝날 때까지 기다린 후 결과를 profile에 저장
+  const profile = await getUserProfile(1); // 1번 user의 프로필 정보를 DB에서 가져옴
+
+  if (!profile) return <div>사용자 정보를 불러올 수 없습니다.</div>
+  
+  // 가져온 데이터에서 필요한 값만 구조 분해
+  const {isFollowing, followerCount, name, bio} = profile;
 
   return (
     <div className="space-y-8 bg-gray-50">

--- a/my-app/src/lib/prisma.ts
+++ b/my-app/src/lib/prisma.ts
@@ -1,0 +1,4 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+export default prisma;

--- a/my-app/src/lib/profile.ts
+++ b/my-app/src/lib/profile.ts
@@ -1,0 +1,36 @@
+import prisma from "@/lib/prisma";
+
+export async function getUserProfile(userId: number) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      name: true,
+      nickname: true,
+      profile: true,
+      createdAt: true,
+      posts: {
+        select: { id: true },
+      },
+      followers: {
+        select: {
+          followerId: true,
+        },
+      },
+      following: {
+        select: {
+          followingId: true,
+        },
+      },
+    },
+  });
+
+  if (!user) return null;
+
+  return {
+    name: user.name,
+    bio: `가입일: ${user.createdAt.toLocaleDateString()}`,
+    followerCount: user.followers.length,
+    isFollowing: false, // 나중에 세션 기반으로 처리
+  };
+}


### PR DESCRIPTION
### ✅ 주요 변경 사항

* DB에서 사용자 프로필 데이터를 불러오는 유틸 함수 `getUserProfile()` 구현
  → 위치: `lib/profile.ts`
* 임시로 `userId = 1` 하드코딩하여 테스트용 유저 정보 fetch
* `page.tsx`에서 `getUserProfile()`을 `await`로 호출하여 비동기 처리
* `null` 응답 시 fallback UI 처리 (`"사용자 정보를 불러올 수 없습니다"`)

---

### 📂 파일 변경 요약

| 파일                     | 변경 내용                                  |
| ---------------------- | -------------------------------------- |
| `lib/profile.ts`       | `getUserProfile(userId: number)` 함수 추가 |
| `lib/prisma.ts`        | Prisma 클라이언트 인스턴스 생성                   |
| `app/profile/page.tsx` | DB에서 유저 프로필 정보 받아 props로 렌더링           |

---

### 🔍 동작 흐름

```ts
// page.tsx
const profile = await getUserProfile(1); // DB 요청 (userId: 1)
```

↓

```ts
// profile.ts
return {
  name,
  bio,
  isFollowing,
  followerCount
};
```

↓

```tsx
<ProfileHeader
  name={name}
  bio={bio}
  isFollowing={isFollowing}
  followerCount={followerCount}
/>
```

---

### 🧪 테스트 사항

* [x] `/profile` 접속 시 DB에서 유저 정보 정상 조회됨
* [x] follower 수 반영됨
* [x] placeholder가 아닌 실제 데이터로 UI 렌더링됨
* [x] 서버 컴포넌트 방식 유지

---

### 🖼️ 참고 이미지

<img width="1912" height="907" alt="profile-fetch-from-db" src="https://github.com/user-attachments/assets/67ac44aa-bd80-430f-9520-0c650b5ff13e" />
