### PR TITLE
refactor: 프로필 pid 기반 구조 정비 및 schema.prisma 동기화

### DIFF
--- a/my-app/prisma/schema.prisma
+++ b/my-app/prisma/schema.prisma
@@ -10,23 +10,22 @@ datasource db {
 model Group {
   code  String @id
   name  String
-  users User[]
   posts Post[]
+  User  User[]
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique
-  name      String
-  password  String
-  nickname  String?
-  profile   String?
-  groupCode String
-  group     Group    @relation(fields: [groupCode], references: [code])
-  createdAt DateTime @default(now())
-  posts     Post[]
-  following Follow[] @relation("Following")
-  followers Follow[] @relation("Follower")
+  pid        Int      @id @default(autoincrement())
+  id         String   @unique @db.VarChar(50)
+  name       String
+  password   String
+  secretCode String
+  createdAt  DateTime @default(now()) @db.Timestamp(6)
+  role       Int      @default(0)
+  followers  Follow[] @relation("Follower")
+  following  Follow[] @relation("Following")
+  posts      Post[]
+  Group      Group    @relation(fields: [secretCode], references: [code])
 }
 
 model Post {
@@ -37,10 +36,12 @@ model Post {
   mood      String
   mentioned String[]
   authorId  Int?
-  author    User?    @relation(fields: [authorId], references: [id], onDelete: Cascade)
   groupCode String
-  group     Group    @relation(fields: [groupCode], references: [code])
   createdAt DateTime @default(now())
+  likes     Int      @default(0)
+  dislikes  Int      @default(0)
+  author    User?    @relation(fields: [authorId], references: [pid], onDelete: Cascade)
+  group     Group    @relation(fields: [groupCode], references: [code])
 }
 
 model Follow {
@@ -48,9 +49,8 @@ model Follow {
   followerId  Int
   followingId Int
   createdAt   DateTime @default(now())
-
-  follower  User @relation("Follower", fields: [followerId], references: [id], onDelete: Cascade)
-  following User @relation("Following", fields: [followingId], references: [id], onDelete: Cascade)
+  follower    User     @relation("Follower", fields: [followerId], references: [pid], onDelete: Cascade)
+  following   User     @relation("Following", fields: [followingId], references: [pid], onDelete: Cascade)
 
   @@unique([followerId, followingId])
 }

--- a/my-app/src/app/profile/page.tsx
+++ b/my-app/src/app/profile/page.tsx
@@ -8,13 +8,29 @@ import PostsGrid from "../ui/Profile/PostsGrid";
 import { getUserProfile } from "@/lib/profile";
 
 export default async function SNSProfile() {
+
+  // 로그인 mock 처리
+  const MOCK_USER_ID = 1; 
+  
+  // 조회 대상 프로필 사용자 ID
+  const profileId = 2; 
+
   // 비동기 함수이므로, DB 요청이 끝날 때까지 기다린 후 결과를 profile에 저장
-  const profile = await getUserProfile(1); // 1번 user의 프로필 정보를 DB에서 가져옴
+  const profile = await getUserProfile(profileId , MOCK_USER_ID);
 
   if (!profile) return <div>사용자 정보를 불러올 수 없습니다.</div>
   
   // 가져온 데이터에서 필요한 값만 구조 분해
-  const {isFollowing, followerCount, name, bio} = profile;
+   const {
+    name,
+    userId,
+    bio,
+    followerCount,
+    followingCount,
+    postCount,
+    isFollowing,
+    isOwner,
+  } = profile;
 
   return (
     <div className="space-y-8 bg-gray-50">
@@ -36,10 +52,14 @@ export default async function SNSProfile() {
         <Card className="mb-8 border-0 shadow-sm bg-white">
           <CardContent className="p-8">
             <ProfileHeader
-              isFollowing={isFollowing}
-              followerCount={followerCount}
               name={name}
+              userId={userId}
               bio={bio}
+              followerCount={followerCount}
+              followingCount={followingCount}
+              postCount={postCount}
+              isFollowing={isFollowing}
+              isOwner={isOwner}
             />
           </CardContent>
         </Card>

--- a/my-app/src/app/ui/Profile/ProfileHeader.tsx
+++ b/my-app/src/app/ui/Profile/ProfileHeader.tsx
@@ -3,15 +3,23 @@ import ProfileInfo from "./ProfileInfo";
 
 interface Props {
   isFollowing: boolean;
+  isOwner: boolean;
   followerCount: number;
+  followingCount: number;
+  postCount: number;
   name: string;
+  userId: string;
   bio: string;
 }
 
 export default function ProfileHeader({
   isFollowing,
+  isOwner,
   followerCount,
+  followingCount,
+  postCount,
   name,
+  userId,
   bio,
 }: Props) {
   return (
@@ -19,8 +27,12 @@ export default function ProfileHeader({
       <ProfileImage name={name}/>
       <ProfileInfo
         isFollowing={isFollowing}
+        isOwner={isOwner}
         followerCount={followerCount}
+        followingCount={followingCount}
+        postCount={postCount}
         name={name}
+        userId={userId}
         bio={bio}
       />
     </div>

--- a/my-app/src/app/ui/Profile/ProfileInfo.tsx
+++ b/my-app/src/app/ui/Profile/ProfileInfo.tsx
@@ -3,16 +3,24 @@ import { UserPlus, UserMinus } from "lucide-react";
 
 interface Props {
   isFollowing: boolean;
+  isOwner: boolean;
   followerCount: number;
+  followingCount: number;
+  postCount: number;
   name: string;
+  userId: string;
   bio: string;
   onToggleFollow?: () => void;
 }
 
 export default function ProfileInfo({
   isFollowing,
+  isOwner,
   followerCount,
+  followingCount,
+  postCount,
   name,
+  userId,
   bio,
   onToggleFollow,
 }: Props) {
@@ -20,30 +28,33 @@ export default function ProfileInfo({
     <div className="flex-1">
       <div className="flex items-center gap-4 mb-4">
         <h2 className="text-2xl font-bold text-[#123F6D]">{name}</h2>
-        <Button
-          onClick={onToggleFollow}
-          className={`px-8 py-2.5 rounded-full font-medium transition-all ${
-            isFollowing
-              ? "bg-gray-100 text-[#123F6D] hover:bg-gray-200 border border-gray-300"
-              : "bg-gradient-to-r from-[#0067AC] to-[#00AEC6] text-white hover:shadow-lg hover:scale-105"
-          }`}
-        >
-          {isFollowing ? (
-            <>
-              <UserMinus className="w-4 h-4 mr-2" />
-              언팔로우
-            </>
-          ) : (
-            <>
-              <UserPlus className="w-4 h-4 mr-2" />
-              팔로우
-            </>
-          )}
-        </Button>
+        {!isOwner && (
+          <Button
+            onClick={onToggleFollow}
+            className={`px-8 py-2.5 rounded-full font-medium transition-all ${
+              isFollowing
+                ? "bg-gray-100 text-[#123F6D] hover:bg-gray-200 border border-gray-300"
+                : "bg-gradient-to-r from-[#0067AC] to-[#00AEC6] text-white hover:shadow-lg hover:scale-105"
+            }`}
+          >
+            {isFollowing ? (
+              <>
+                <UserMinus className="w-4 h-4 mr-2" />
+                언팔로우
+              </>
+            ) : (
+              <>
+                <UserPlus className="w-4 h-4 mr-2" />
+                팔로우
+              </>
+            )}
+          </Button>
+        )}
       </div>
 
       <p className="text-[#123F6D]/80 text-lg mb-6 leading-relaxed">
-        {bio}
+        {bio} <br />
+        @{userId}
       </p>
 
       <div className="flex items-center gap-8 mb-6">
@@ -53,13 +64,16 @@ export default function ProfileInfo({
           </div>
           <div className="text-sm text-[#123F6D]/60">팔로워</div>
         </div>
-        {/* 팔로잉, 게시물은 하드코딩된 상태 */}
         <div className="text-center">
-          <div className="text-2xl font-bold text-[#123F6D]">892</div>
+          <div className="text-2xl font-bold text-[#123F6D]">
+            {followingCount.toLocaleString()}
+          </div>
           <div className="text-sm text-[#123F6D]/60">팔로잉</div>
         </div>
         <div className="text-center">
-          <div className="text-2xl font-bold text-[#123F6D]">156</div>
+          <div className="text-2xl font-bold text-[#123F6D]">
+            {postCount.toLocaleString()}
+          </div>
           <div className="text-sm text-[#123F6D]/60">게시물</div>
         </div>
       </div>

--- a/my-app/src/lib/profile.ts
+++ b/my-app/src/lib/profile.ts
@@ -1,36 +1,32 @@
 import prisma from "@/lib/prisma";
 
-export async function getUserProfile(userId: number) {
+export async function getUserProfile(profileId: number, currentUserId: number) {
   const user = await prisma.user.findUnique({
-    where: { id: userId },
+    where: { pid: profileId },
     select: {
+      pid: true,
       id: true,
       name: true,
-      nickname: true,
-      profile: true,
       createdAt: true,
-      posts: {
-        select: { id: true },
-      },
-      followers: {
-        select: {
-          followerId: true,
-        },
-      },
-      following: {
-        select: {
-          followingId: true,
-        },
-      },
+      followers: { select: { followerId: true } },
+      following: { select: { followingId: true } },
+      posts: { select: { id: true } },
     },
   });
 
   if (!user) return null;
 
+  const isFollowing = user.followers.some(f => f.followerId === currentUserId);
+  const isOwner = profileId === currentUserId;
+
   return {
     name: user.name,
+    userId: user.id,
     bio: `가입일: ${user.createdAt.toLocaleDateString()}`,
     followerCount: user.followers.length,
-    isFollowing: false, // 나중에 세션 기반으로 처리
+    followingCount: user.following.length,
+    postCount: user.posts.length,
+    isFollowing,
+    isOwner,
   };
 }


### PR DESCRIPTION
## ✅ 주요 변경 사항

- User 모델: 기존 `id(Int)` → `pid(Int)` 구조로 전체 로직 전환
- `getUserProfile()` 내부 쿼리를 pid 기준으로 수정
- `nickname` 필드 제거 → `id (user01 등)`을 대체 표시용으로 사용
- `ProfileHeader`, `ProfileInfo` 등의 props 구조 리팩토링
- `schema.prisma` 수정 및 필드/타입 정리

---

## 🧪 테스트 방법

- `/profile` 진입 시 MOCK_USER_ID 기준으로 본인 프로필 출력
- 팔로워 수, 게시물 수, ID(`@user01`) 표시 정상 동작 확인

---

## 💡 참고 사항

- 현재는 `/profile` 단일 경로만 존재합니다
- 추후 `/profile/[profileId]` 경로 분리 및 SNSProfile 컴포넌트 분리는 후속 브랜치에서 처리 예정
