### PR TITLE
refactor: 프로필 페이지 pid 기반 리팩토링 및 서버 컴포넌트 전환

### DIFF
--- a/my-app/src/app/profile/[profileId]/page.jsx
+++ b/my-app/src/app/profile/[profileId]/page.jsx
@@ -1,0 +1,15 @@
+export const dynamic = "force-dynamic";
+
+import { getUserProfile } from "@/lib/profile";
+import SNSProfile from "@/app/ui/Profile/SNSProfile";
+import { notFound } from "next/navigation";
+
+export default async function Page({ params }) {
+  const profileId = Number(params.profileId);
+  const MOCK_USER_ID = 1;
+
+  const profile = await getUserProfile(profileId, MOCK_USER_ID);
+  if (!profile) return notFound();
+
+  return <SNSProfile profile={profile} />;
+}

--- a/my-app/src/app/profile/page.tsx
+++ b/my-app/src/app/profile/page.tsx
@@ -1,77 +1,11 @@
-// 서버 컴포넌트로 전환
-
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Settings, MoreHorizontal, Grid3X3 } from "lucide-react";
-import ProfileHeader from "../ui/Profile/ProfileHeader";
-import PostsGrid from "../ui/Profile/PostsGrid";
 import { getUserProfile } from "@/lib/profile";
+import SNSProfile from "@/app/ui/Profile/SNSProfile";
 
-export default async function SNSProfile() {
+export default async function MyProfilePage() {
+  const MOCK_USER_ID = 1;
+  const profile = await getUserProfile(MOCK_USER_ID, MOCK_USER_ID);
 
-  // 로그인 mock 처리
-  const MOCK_USER_ID = 1; 
-  
-  // 조회 대상 프로필 사용자 ID
-  const profileId = 2; 
+  if (!profile) return <div>내 프로필 정보를 불러올 수 없습니다.</div>;
 
-  // 비동기 함수이므로, DB 요청이 끝날 때까지 기다린 후 결과를 profile에 저장
-  const profile = await getUserProfile(profileId , MOCK_USER_ID);
-
-  if (!profile) return <div>사용자 정보를 불러올 수 없습니다.</div>
-  
-  // 가져온 데이터에서 필요한 값만 구조 분해
-   const {
-    name,
-    userId,
-    bio,
-    followerCount,
-    followingCount,
-    postCount,
-    isFollowing,
-    isOwner,
-  } = profile;
-
-  return (
-    <div className="space-y-8 bg-gray-50">
-      <div className="sticky top-0 z-10 bg-white">
-        <div className="border-b border-gray-200 px-6 py-4 flex items-center justify-between">
-          <h1 className="text-xl font-semibold text-[#123F6D]">프로필</h1>
-          <div className="flex items-center gap-3">
-            <Button variant="ghost" size="sm" className="text-[#123F6D]">
-              <Settings className="w-5 h-5" />
-            </Button>
-            <Button variant="ghost" size="sm" className="text-[#123F6D]">
-              <MoreHorizontal className="w-5 h-5" />
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      <div className="max-w-6xl mx-auto px-6 py-8">
-        <Card className="mb-8 border-0 shadow-sm bg-white">
-          <CardContent className="p-8">
-            <ProfileHeader
-              name={name}
-              userId={userId}
-              bio={bio}
-              followerCount={followerCount}
-              followingCount={followingCount}
-              postCount={postCount}
-              isFollowing={isFollowing}
-              isOwner={isOwner}
-            />
-          </CardContent>
-        </Card>
-
-        <div className="mb-6">
-          <div className="flex items-center justify-center gap-2 mb-8">
-            <Grid3X3 className="w-5 h-5 text-[#123F6D]" />
-            <span className="text-lg font-semibold text-[#123F6D]">게시물</span>
-          </div>
-          <PostsGrid />
-        </div>
-      </div>
-    </div>
-  );
+  return <SNSProfile profile={profile} />;
 }

--- a/my-app/src/app/ui/Profile/PostCard.tsx
+++ b/my-app/src/app/ui/Profile/PostCard.tsx
@@ -1,33 +1,30 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { Heart, MessageCircle, Share2 } from "lucide-react";
+interface Post {
+  id: number;
+  imageUrl?: string | null;
+  mood: string;
+  content: string;
+}
 
-export default function PostCard({ index }: { index: number }) {
+export default function PostCard({ post }: { post: Post }) {
   return (
-    <Card className="group cursor-pointer border-0 shadow-sm hover:shadow-xl transition-all duration-300 overflow-hidden">
-      <CardContent className="p-0">
-        <div className="aspect-square bg-gradient-to-br from-[#00AEC6] to-[#0067AC] relative overflow-hidden">
-          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-all duration-300 flex items-center justify-center">
-            <div className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity">
-              게시물 {index + 1}
-            </div>
-          </div>
-          <div className="absolute bottom-4 left-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity">
-            <div className="flex justify-between items-center text-white text-sm">
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-1">
-                  <Heart className="w-4 h-4" />
-                  <span>24</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <MessageCircle className="w-4 h-4" />
-                  <span>8</span>
-                </div>
-              </div>
-              <Share2 className="w-4 h-4" />
-            </div>
-          </div>
+    <div className="group cursor-pointer border-0 shadow-sm hover:shadow-xl transition-all duration-300 overflow-hidden rounded-md">
+      <div className="aspect-square bg-gray-100 relative overflow-hidden">
+        {post.imageUrl ? (
+          <img
+            src={`https://picsum.photos/seed/${post.id}/300`}
+            alt="게시물 이미지"
+            className="object-cover w-full h-full"
+          />
+        ) : (
+          <div className="flex items-center justify-center h-full text-gray-400">이미지 없음</div>
+        )}
+
+        <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-all flex items-center justify-center">
+          <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity">
+            {post.mood}
+          </span>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/my-app/src/app/ui/Profile/PostsGrid.tsx
+++ b/my-app/src/app/ui/Profile/PostsGrid.tsx
@@ -1,10 +1,34 @@
 import PostCard from "./PostCard";
+import prisma from "@/lib/prisma";
 
-export default function PostsGrid() {
+interface Props {
+  userPid: number;
+}
+
+export default async function PostsGrid({ userPid }: Props) {
+  const posts = await prisma.post.findMany({
+    where: {
+      authorId: userPid,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    select: {
+      id: true,
+      imageUrl: true,
+      mood: true,
+      content: true,
+    },
+  });
+
+  if (!posts.length) {
+    return <div className="text-center text-gray-500 py-12">게시물이 없습니다.</div>;
+  }
+
   return (
     <div className="grid grid-cols-3 gap-6">
-      {Array.from({ length: 9 }, (_, i) => (
-        <PostCard key={i} index={i} />
+      {posts.map((post) => (
+        <PostCard key={post.id} post={post} />
       ))}
     </div>
   );

--- a/my-app/src/app/ui/Profile/ProfileHeader.tsx
+++ b/my-app/src/app/ui/Profile/ProfileHeader.tsx
@@ -24,7 +24,7 @@ export default function ProfileHeader({
 }: Props) {
   return (
     <div className="flex items-start gap-8">
-      <ProfileImage name={name}/>
+      <ProfileImage name={name} userId={userId}/>
       <ProfileInfo
         isFollowing={isFollowing}
         isOwner={isOwner}

--- a/my-app/src/app/ui/Profile/ProfileImage.tsx
+++ b/my-app/src/app/ui/Profile/ProfileImage.tsx
@@ -13,6 +13,7 @@ export default function ProfileImage({ name, userId }: { name: string; userId: s
             height={128}
             className="w-full h-full rounded-full object-cover"
             unoptimized
+            priority 
           />
         </div>
       </div>

--- a/my-app/src/app/ui/Profile/ProfileImage.tsx
+++ b/my-app/src/app/ui/Profile/ProfileImage.tsx
@@ -1,16 +1,20 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Camera } from "lucide-react";
+import Image from "next/image";
 
-export default function ProfileImage({ name }:{ name: string }) {
+export default function ProfileImage({ name, userId }: { name: string; userId: string }) {
   return (
     <div className="relative group">
       <div className="w-32 h-32 rounded-full bg-gradient-to-br from-[#00AEC6] via-[#0067AC] to-[#123F6D] p-1 shadow-lg">
-        <Avatar className="w-full h-full border-4 border-white">
-          <AvatarImage src="/placeholder.svg?height=128&width=128&text=Profile" />
-          <AvatarFallback className="bg-gradient-to-br from-[#00AEC6] to-[#0067AC] text-white text-lg font-medium">
-            {name}
-          </AvatarFallback>
-        </Avatar>
+        <div className="w-full h-full border-4 border-white rounded-full overflow-hidden bg-white">
+          <Image
+            src={`https://api.dicebear.com/9.x/bottts-neutral/svg?seed=${userId}&cache=true`}
+            alt={`${name}의 프로필 이미지`}
+            width={128}
+            height={128}
+            className="w-full h-full rounded-full object-cover"
+            unoptimized
+          />
+        </div>
       </div>
       <div className="absolute inset-0 rounded-full bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center cursor-pointer">
         <Camera className="w-6 h-6 text-white" />

--- a/my-app/src/app/ui/Profile/SNSProfile.tsx
+++ b/my-app/src/app/ui/Profile/SNSProfile.tsx
@@ -1,0 +1,68 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Grid3X3, Settings, MoreHorizontal } from "lucide-react";
+import ProfileHeader from "./ProfileHeader";
+import PostsGrid from "./PostsGrid";
+import { UserProfile } from "@/types/user"; // 리턴 타입 정의 위치는 상황에 따라 조정
+
+interface Props {
+  profile: UserProfile;
+}
+
+export default function SNSProfile({ profile }: Props) {
+  const {
+    name,
+    userId,
+    bio,
+    followerCount,
+    followingCount,
+    postCount,
+    isFollowing,
+    isOwner,
+  } = profile;
+
+  return (
+    <div className="space-y-8 bg-gray-50">
+      <div className="sticky top-0 z-10 bg-white">
+        <div className="border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+          <h1 className="text-xl font-semibold text-[#123F6D]">프로필</h1>
+          {!isOwner && (
+            <div className="flex items-center gap-3">
+              <Button variant="ghost" size="sm" className="text-[#123F6D]">
+                <Settings className="w-5 h-5" />
+              </Button>
+              <Button variant="ghost" size="sm" className="text-[#123F6D]">
+                <MoreHorizontal className="w-5 h-5" />
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="max-w-6xl mx-auto px-6 py-8">
+        <Card className="mb-8 border-0 shadow-sm bg-white">
+          <CardContent className="p-8">
+            <ProfileHeader
+              name={name}
+              userId={userId}
+              bio={bio}
+              followerCount={followerCount}
+              followingCount={followingCount}
+              postCount={postCount}
+              isFollowing={isFollowing}
+              isOwner={isOwner}
+            />
+          </CardContent>
+        </Card>
+
+        <div className="mb-6">
+          <div className="flex items-center justify-center gap-2 mb-8">
+            <Grid3X3 className="w-5 h-5 text-[#123F6D]" />
+            <span className="text-lg font-semibold text-[#123F6D]">게시물</span>
+          </div>
+          <PostsGrid userPid={profile.pid} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/lib/profile.ts
+++ b/my-app/src/lib/profile.ts
@@ -1,12 +1,13 @@
 import prisma from "@/lib/prisma";
+import { UserProfile } from "@/types/user";
 
-export async function getUserProfile(profileId: number, currentUserId: number) {
+export async function getUserProfile(profileId: number, currentUserId: number): Promise<UserProfile | null> {
   const user = await prisma.user.findUnique({
     where: { pid: profileId },
     select: {
       pid: true,
-      id: true,
       name: true,
+      id: true,
       createdAt: true,
       followers: { select: { followerId: true } },
       following: { select: { followingId: true } },
@@ -20,6 +21,7 @@ export async function getUserProfile(profileId: number, currentUserId: number) {
   const isOwner = profileId === currentUserId;
 
   return {
+    pid: user.pid,
     name: user.name,
     userId: user.id,
     bio: `가입일: ${user.createdAt.toLocaleDateString()}`,

--- a/my-app/src/types/user.ts
+++ b/my-app/src/types/user.ts
@@ -1,0 +1,11 @@
+export interface UserProfile {
+  pid: number; // 내부 DB 식별자 (게시글/팔로우에 필요)
+  name: string;
+  userId: string;
+  bio: string;
+  followerCount: number;
+  followingCount: number;
+  postCount: number;
+  isFollowing: boolean;
+  isOwner: boolean;
+}

--- a/my-app/tsconfig.json
+++ b/my-app/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/app/ui/default/feed/post.jsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/app/ui/default/feed/post.jsx", "src/app/profile/[profileId]/page.jsx"],
   "exclude": ["node_modules", "prisma"]
 }


### PR DESCRIPTION
### ✅ 주요 변경 사항
- 프로필 페이지를 서버 컴포넌트로 전환하고 [profileId] 경로 적용
- ProfileHeader, PostsGrid 등 하위 컴포넌트의 props 구조 정비 및 최적화
- dicebear 프로필 이미지 LCP 감지 대응을 위한 priority 속성 추가
  - 메인 프로필 이미지가 Largest Contentful Paint(LCP)로 감지됨
  - 성능 최적화를 위해 Next.js Image 컴포넌트에 priority 속성 추가
  - 위 요소가 fold 위에서 바로 보여지므로 preload 대상에 포함시킴

### 💡 참고 사항
- Follow/Unfollow API는 후속 브랜치에서 개발 예정
- 타입 정의는 `@/types/user.ts`에서 관리
- 현재는 하드코딩된 userId(pid=1) 기준으로 테스트되고 있음
- page.jsx
  - Next.js 빌드 시 .next/types 내부 타입 캐시 오류로 인해 params 타입 충돌 발생
  - 임시 대응으로 [profileId]/page.tsx 대신 page.jsx 사용 및 타입 제거