### PR TITLE
[#12] feat: follow/unfollow API 구현

### DIFF
--- a/my-app/src/api/follow/route.ts
+++ b/my-app/src/api/follow/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+// [POST] /api/follow → 팔로우 추가
+export async function POST(req: NextRequest) {
+  // 요청 body에서 followerId, followingId 추출
+  const { followerId, followingId } = await req.json();
+
+  // 필수 값 누락 시 400 반환
+  if (!followerId || !followingId) {
+    return NextResponse.json({ message: "Missing ids" }, { status: 400 });
+  }
+
+  try {
+    // Follow 테이블에 새로운 관계 추가
+    await prisma.follow.create({
+      data: {
+        followerId,
+        followingId,
+      },
+    });
+
+    return NextResponse.json({ message: "Followed" }, { status: 200 });
+  } catch (error) {
+    // 이미 팔로우했거나 DB 에러 발생 시
+    return NextResponse.json({ message: "Already followed or DB error" }, { status: 500 });
+  }
+}
+
+// [DELETE] /api/follow → 팔로우 제거 (언팔로우)
+export async function DELETE(req: NextRequest) {
+  // 요청 body에서 followerId, followingId 추출
+  const { followerId, followingId } = await req.json();
+
+  // 필수 값 누락 시 400 반환
+  if (!followerId || !followingId) {
+    return NextResponse.json({ message: "Missing ids" }, { status: 400 });
+  }
+
+  try {
+    // 해당 관계를 삭제 (deleteMany 사용 → 안전하게 중복 제거)
+    await prisma.follow.deleteMany({
+      where: {
+        followerId,
+        followingId,
+      },
+    });
+
+    return NextResponse.json({ message: "Unfollowed" }, { status: 200 });
+  } catch (error) {
+    // 삭제 실패 시
+    return NextResponse.json({ message: "Error unfollowing" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
### 🛠️ 관련 이슈
closes #12 

---

### ✅ 주요 변경 사항

* `/api/follow` API 핸들러 구현

  * `POST`: 팔로우 관계 생성
  * `DELETE`: 언팔로우 처리
* `followerId`, `followingId`를 JSON body로 받아 처리
* 예외 처리:

  * 필드 누락 시 `400 Bad Request`
  * 중복 또는 DB 에러 시 `500 Internal Server Error`
* Prisma의 `create`, `deleteMany` 사용

---

### 💡 참고 사항

* 현재는 mock userId (`pid = 1`) 기준으로 테스트됨
* 후속 브랜치: `feat/profile-follow-ui`
