### PR TITLE
fix: 프로필페이지 서버측 예외 에러 해결

### DIFF
--- a/my-app/src/app/profile/page.tsx
+++ b/my-app/src/app/profile/page.tsx
@@ -1,20 +1,13 @@
-export const dynamic = "force-dynamic";
-
 import { getUserProfile } from "@/lib/profile";
 import SNSProfile from "@/app/ui/Profile/SNSProfile";
-import { notFound } from "next/navigation";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ profileId: string }>; // Promise 타입으로 변경
-}) {
-  const { profileId } = await params; // params를 await
-  const pid = parseInt(profileId, 10);
+export default async function MyProfilePage() {
   const MOCK_USER_ID = 1;
+  const profile = await getUserProfile(MOCK_USER_ID, MOCK_USER_ID);
 
-  const profile = await getUserProfile(pid, MOCK_USER_ID);
-  if (!profile) return notFound();
+  if (!profile) {
+    return <div>내 프로필 정보를 불러올 수 없습니다.</div>;
+  }
 
-  return <SNSProfile profile={profile} pid={pid} />; // ✅ props로 전달
+  return <SNSProfile profile={profile} pid={MOCK_USER_ID} />;
 }


### PR DESCRIPTION
## 문제
- `/profile` 접근 시 서버 사이드 예외 발생
- `pid` 변수 undefined 오류

## 해결
- MyProfilePage에서 undefined `pid` 변수를 `MOCK_USER_ID`로 수정
- 프로필 데이터 로딩 에러 핸들링 개선

## 테스트
- [x] `/profile` 페이지 정상 로드 확인
- [x] `/profile/[id]` 페이지 정상 작동 확인